### PR TITLE
shrink plot response size by dropping unnecessary zeros

### DIFF
--- a/lyra/lyra/home/templates/ts_form.html
+++ b/lyra/lyra/home/templates/ts_form.html
@@ -16,6 +16,13 @@
         <input type="text" name ="variable" id="variable" value='11.00'>
         <label for="variable">Variable</label>
     </div>
+    <div >
+        <select id="datasource" name="datasource">
+            <option value="A">Archival (A)</option>
+            <option value="TELEMETRY">Provisional (Telemetry)</option>
+        </select>
+        <label for="datasource">Data Source</label>
+    </div>
     
     <div >
         <tr>
@@ -47,11 +54,14 @@
           <option value="mean">Average</option>
           <option value="max">Maximum</option>
           <option value="min">Minimum</option>
+          <!-- <option value="point">Data Point</option> -->
         </select>
         <label for="data_type">Aggregation Mode</label>
     </div>
     <div >
         <select id="interval" name="interval">
+          <!-- <option value="second">Second</option>
+          <option value="minute">Minute</option> -->
           <option value="hour">Hourly</option>
           <option value="day">Daily</option>
           <option value="month">Monthly</option>

--- a/lyra/lyra/home/views/main.py
+++ b/lyra/lyra/home/views/main.py
@@ -21,7 +21,7 @@ async def home(request: Request):
 async def timeseriesfunc(request: Request):
 
     sitelist_file = Path(lyra.__file__).parent / "static" / "site_list.json"
-    sitelist = json.loads(sitelist_file.read_text())['sites']
+    sitelist = json.loads(sitelist_file.read_text())["sites"]
 
     plot_function = "plot_trace"
     return templates.TemplateResponse(

--- a/lyra/lyra/tasks/build_static_references.py
+++ b/lyra/lyra/tasks/build_static_references.py
@@ -8,65 +8,64 @@ from lyra.api.endpoints import hydstra
 
 def site_preferred_variables():
 
-    promise = asyncio.run( hydstra.get_variables(None, 'A', None))
+    promise = asyncio.run(hydstra.get_variables(None, "A", None))
     vars_by_site = []
 
-    for blob in promise["_return"]['sites']:
-        site = blob['site']
-        for variable in blob['variables']:
-            variable['site']=site
+    for blob in promise["_return"]["sites"]:
+        site = blob["site"]
+        for variable in blob["variables"]:
+            variable["site"] = site
             vars_by_site.append(variable)
 
     variables = pandas.DataFrame(vars_by_site)
 
     use_vars = {
-        'Rainfall':{'agg':'tot'}, #hydstra codes, not pandas ones.
-        'Discharge':{'agg':"mean"}
+        "Rainfall": {"agg": "tot"},  # hydstra codes, not pandas ones.
+        "Discharge": {"agg": "mean"},
     }
 
-    variables = (
-        variables
-        .merge(
-            variables.query("name in @use_vars.keys()").groupby(["site", "name"]).variable
-            .min() # <-- use the minimum number as the 'preferred value for now. Just a WAG.'
-            .reset_index()
-            .assign(preferred=True)
-            .set_index(['site', 'name', 'variable'])['preferred'],
-            left_on=["site", "name", 'variable'],
-            right_index=True,
-            how='left',
-
-        )
-        .fillna(False)
-    )
+    variables = variables.merge(
+        variables.query("name in @use_vars.keys()")
+        .groupby(["site", "name"])
+        .variable.min()  # <-- use the minimum number as the 'preferred value for now. Just a WAG.'
+        .reset_index()
+        .assign(preferred=True)
+        .set_index(["site", "name", "variable"])["preferred"],
+        left_on=["site", "name", "variable"],
+        right_index=True,
+        how="left",
+    ).fillna(False)
 
     return variables
 
+
 def site_variable_map(variables: pandas.DataFrame):
     mapping = (
-        variables
-        .query("preferred")
-        .assign(label = lambda df: df['name'] + "-"+df['variable'])
-        .groupby(['site'])
-        .apply(lambda x: x[['label','variable']].set_index('label').to_dict()['variable'])
+        variables.query("preferred")
+        .assign(label=lambda df: df["name"] + "-" + df["variable"])
+        .groupby(["site"])
+        .apply(
+            lambda x: x[["label", "variable"]].set_index("label").to_dict()["variable"]
+        )
     )
 
-    return {'site_variable_mapping' : mapping.to_dict()}
+    return {"site_variable_mapping": mapping.to_dict()}
+
 
 if __name__ == "__main__":
 
     cur_dir = Path(__file__).parent
 
-    static_dir = cur_dir.parent / 'static'
+    static_dir = cur_dir.parent / "static"
 
     variables = site_preferred_variables()
-    with open(static_dir / "site_variables.json", 'w') as f:
-        json.dump({'site_variables': variables.to_dict('records')}, f, indent=2)
+    with open(static_dir / "site_variables.json", "w") as f:
+        json.dump({"site_variables": variables.to_dict("records")}, f, indent=2)
 
     site_var_mapping = site_variable_map(variables)
-    with open(static_dir / "site_variable_mapping.json", 'w') as f:
+    with open(static_dir / "site_variable_mapping.json", "w") as f:
         json.dump(site_var_mapping, f, indent=2)
 
-    with open(static_dir / "site_list.json", 'w') as f:
+    with open(static_dir / "site_list.json", "w") as f:
         sitelist_response = asyncio.run(hydstra.get_site_list())
-        json.dump(sitelist_response['_return'], f, indent=2)
+        json.dump(sitelist_response["_return"], f, indent=2)


### PR DESCRIPTION
shrink plot response size by dropping zeros if both surrounding values are also zero. 
eg: 
`[1,2,3,1,0,0,0,0,1,2,3]`
becomes
`[1,2,3,1,0,0,1,2,3]`

this preserves all important timestamped transitions from zeros to any value, so should be safe for most/all plotting purposes. 

also `black`'d
also added selectable datasource to frontend